### PR TITLE
Use docker image in example compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,6 @@ Then, edit the `.env` file to set your environment variables. The file contains 
 
 ### Docker
 
-> [!WARNING]
-> The project doesn't publish Docker images yet, so you need to build the image yourself.
-> The default compose configuration takes care of this for you, however.
-
 The easiest way to set up Λύρα is to use Docker. Start by creating a copy of the example docker compose file:
 
 ```bash

--- a/compose.example.yaml
+++ b/compose.example.yaml
@@ -47,10 +47,7 @@ services:
       retries: 5
 
   lyra:
-    build:
-      dockerfile: Dockerfile
-      args:
-        - DOCKER_BUILD_TYPE=${DOCKER_BUILD_TYPE:-release}
+    image: ghcr.io/lyra-music/lyra:latest
     environment:
       SQLX_OFFLINE: true
       DATABASE_URL: ${DATABASE_URL}


### PR DESCRIPTION
Changes the example docker compose file to use the images built by actions. Also adjusts the README to remove a relevant disclaimer.