### PR TITLE
Fix `/play` sending double server muted notice

### DIFF
--- a/lyra/src/component/connection/join.rs
+++ b/lyra/src/component/connection/join.rs
@@ -340,6 +340,7 @@ fn stage_fmt(txt: &str, stage: bool) -> Cow<'_, str> {
 async fn handle_response(
     response: Response,
     ctx: &mut GuildCtx<impl RespondViaMessage + FollowupCtxKind>,
+    send_muted_notice: bool,
 ) -> Result<InVoiceCachedVoiceState, HandleResponseError> {
     let (joined, empty) = match response {
         Response::Joined { voice, empty } => {
@@ -382,8 +383,7 @@ async fn handle_response(
     }
 
     let state = ctx.current_voice_state().ok_or(CacheError)?;
-    let muted = state.mute();
-    if muted {
+    if send_muted_notice && state.mute() {
         ctx.suspf("**Currently server muted**; Some features will be limited.")
             .await?;
     }
@@ -393,14 +393,14 @@ async fn handle_response(
 pub async fn auto(
     ctx: &mut GuildCtx<impl RespondViaMessage + FollowupCtxKind>,
 ) -> Result<InVoiceCachedVoiceState, AutoJoinError> {
-    Ok(handle_response(impl_auto_join(ctx).await?, ctx).await?)
+    Ok(handle_response(impl_auto_join(ctx).await?, ctx, false).await?)
 }
 
 pub async fn join(
     ctx: &mut GuildCtx<impl RespondViaMessage + FollowupCtxKind>,
     channel: Option<InteractionChannel>,
 ) -> Result<InVoiceCachedVoiceState, JoinError> {
-    Ok(handle_response(impl_join(ctx, channel).await?, ctx).await?)
+    Ok(handle_response(impl_join(ctx, channel).await?, ctx, true).await?)
 }
 
 /// Joins a voice/stage channel.

--- a/lyra/src/gateway/interaction.rs
+++ b/lyra/src/gateway/interaction.rs
@@ -431,10 +431,12 @@ async fn match_error(
     }
 }
 
+const SUPPRESSED_MESSAGE: &str = "Currently server muted.";
+
 async fn match_suppressed(error: &SuppressedError, mut i: CtxHead) -> UnitRespondOrFollowupResult {
     match error {
         SuppressedError::Muted => {
-            i.wrng_f("Currently server muted.").await?;
+            i.wrng_f(SUPPRESSED_MESSAGE).await?;
         }
         SuppressedError::NotSpeaker => {
             i.wrng_f("Not currently a speaker in this stage channel.")
@@ -450,8 +452,7 @@ async fn match_autojoin_suppressed(
 ) -> UnitRespondResult {
     match error {
         AutoJoinSuppressedError::Muted => {
-            i.suspf("Can't use this command as is currently server muted.")
-                .await?;
+            i.wrngf(SUPPRESSED_MESSAGE).await?;
         }
         AutoJoinSuppressedError::StillNotSpeaker { last_followup_id } => {
             i.update_followup(*last_followup_id)


### PR DESCRIPTION
This happens when the bot is not in vc but server muted and /play used.