### PR TITLE
Fix queue advancing disabling when no curr tracks

### DIFF
--- a/lyra/src/command/require.rs
+++ b/lyra/src/command/require.rs
@@ -59,12 +59,6 @@ impl PlayerInterface {
         self.context.data_unwrapped()
     }
 
-    pub async fn disable_advancing_and_stop_with(&self, queue: &Queue) -> LavalinkResult<()> {
-        queue.disable_advancing();
-        self.context.stop_now().await?;
-        Ok(())
-    }
-
     pub async fn update_voice_channel(&self, voice_is_empty: bool) -> LavalinkResult<()> {
         let mut update_player = lavalink_rs::model::http::UpdatePlayer {
             voice: Some(

--- a/lyra/src/component/playback/back.rs
+++ b/lyra/src/component/playback/back.rs
@@ -49,9 +49,19 @@ pub async fn back(
 ) -> Result<(), PlayPauseError> {
     let mut data_w = data.write().await;
     let queue = data_w.queue_mut();
+    dbg!("before");
+    queue.print();
+
     queue.downgrade_repeat_mode();
-    queue.disable_advancing();
+    if current_track_title.is_some() {
+        // CORRECTNESS: the current track is present and will be ending via the
+        // `play_now` call later, so this is correct.
+        queue.disable_advancing();
+    }
     queue.recede();
+
+    queue.print();
+    dbg!("after");
     let item = queue.current().expect("queue must be non-empty");
     player.context.play_now(item.data()).await?;
     let message = current_track_title.map_or_else(

--- a/lyra/src/component/playback/jump/backward.rs
+++ b/lyra/src/component/playback/jump/backward.rs
@@ -23,9 +23,11 @@ impl BotSlashCommand for Backward {
 
         let mut data_w = data.write().await;
         let queue = require::queue_not_empty_mut(&mut data_w)?;
-        if let Ok(current_track) = require::current_track(queue) {
-            check::current_track_is_users(&current_track, in_voice_with_user)?;
+        let current_track = require::current_track(queue);
+        if let Ok(ref curr) = current_track {
+            check::current_track_is_users(curr, in_voice_with_user)?;
         }
+        let current_track_exists = current_track.is_ok();
 
         #[expect(clippy::cast_possible_truncation)]
         let tracks = self.tracks.unsigned_abs() as usize;
@@ -44,7 +46,11 @@ impl BotSlashCommand for Backward {
         };
 
         queue.downgrade_repeat_mode();
-        queue.disable_advancing();
+        if current_track_exists {
+            // CORRECTNESS: the current track is present and will be ending via the
+            // `play_now` call later, so this is correct
+            queue.disable_advancing();
+        }
 
         let track = queue[index].data();
         let txt = format!("↩️ Jumped to `{}` (`#{}`).", track.info.title, index + 1);

--- a/lyra/src/component/playback/jump/forward.rs
+++ b/lyra/src/component/playback/jump/forward.rs
@@ -51,6 +51,13 @@ impl BotSlashCommand for Forward {
         check::all_users_track(queue, skipped, in_voice_with_user)?;
 
         queue.downgrade_repeat_mode();
+
+        // CORRECTNESS: the current track will always exist as this command cannot be used when the
+        // current track doesn't exist, which is possible in two scenarios:
+        // - queue is empty (which is impossible because of the `queue_not_empty_mut` check)
+        // - the current queue index is past the end of the queue (which will early returned as
+        //   "no where else to jump to"`)
+        // the current track will be ending via the `play_now` call later, so this is correct.
         queue.disable_advancing();
 
         let track = queue[new_position].data();

--- a/lyra/src/component/playback/skip.rs
+++ b/lyra/src/component/playback/skip.rs
@@ -44,7 +44,14 @@ pub async fn skip(
     let mut data_w = data.write().await;
     let queue = data_w.queue_mut();
     queue.downgrade_repeat_mode();
+
+    // CORRECTNESS: the current track is present in both scenarios:
+    // - when called from `/skip`: verified via `queue_not_empty` and `current_track` checks
+    // - when called from the skip button on the controller: if the controller exists, then
+    //   it must only mean the current track also exists.
+    // and will be ending via the `play_now` call later, so this is correct.
     queue.disable_advancing();
+
     queue.advance();
     if let Some(item) = queue.current() {
         player.context.play_now(item.data()).await?;

--- a/lyra/src/component/queue/clear.rs
+++ b/lyra/src/component/queue/clear.rs
@@ -33,7 +33,14 @@ impl BotSlashCommand for Clear {
         let positions = (1..=queue.len()).filter_map(NonZeroUsize::new);
         check::all_users_track(queue, positions, in_voice_with_user)?;
 
-        player.disable_advancing_and_stop_with(queue).await?;
+        if require::current_track(queue).is_ok() {
+            // CORRECTNESS: the current track is present and will be ending via the
+            // `stop_now` call later, so this is correct
+            queue.disable_advancing();
+
+            player.context.stop_now().await?;
+        }
+
         drop(data_r);
         ctx.get_conn().dispatch(Event::QueueClear).await?;
 

--- a/lyra/src/component/queue/mod.rs
+++ b/lyra/src/component/queue/mod.rs
@@ -293,11 +293,14 @@ async fn impl_remove(
         queue.downgrade_repeat_mode();
         let next = queue.current().map(QueueItem::data);
 
+        // CORRECTNESS: the current track is present (and will be removed from the queue) and
+        // will be ending via the `play_now` or `stop_now` call later, so this is correct.
+        queue.disable_advancing();
+
         if let Some(next) = next {
-            queue.disable_advancing();
             player.context.play_now(next).await?;
         } else {
-            player.disable_advancing_and_stop_with(queue).await?;
+            player.context.stop_now().await?;
         }
     }
     let (queue_len, queue_position) = (queue.len(), queue.position());

--- a/lyra/src/lavalink/model/queue.rs
+++ b/lyra/src/lavalink/model/queue.rs
@@ -1,5 +1,6 @@
 use std::{collections::VecDeque, num::NonZeroUsize, time::Duration};
 
+use itertools::Itertools;
 use lavalink_rs::model::track::TrackData;
 use rayon::iter::{IntoParallelIterator, ParallelExtend, ParallelIterator};
 use tokio::sync::watch;
@@ -258,6 +259,12 @@ impl Queue {
         self.advancing_enabler.send_replace(state);
     }
 
+    /// Disables the queue advancing
+    ///
+    /// # Correctness
+    ///
+    /// This function must only be called when the current track is ending.
+    /// Otherwise, this will lead to incorrect queue advancing behaviour.
     pub fn disable_advancing(&self) {
         tracing::debug!("disabling queue advancing");
         self.set_advancing_state(false);
@@ -315,6 +322,14 @@ impl Queue {
     #[inline]
     pub fn insert(&mut self, index: usize, value: Item) {
         self.inner.insert(index, value);
+    }
+
+    pub fn print(&self) {
+        println!(
+            "index={} inner:[{}]",
+            self.index,
+            self.inner.iter().map(|x| &x.data().info.title).join(", ")
+        );
     }
 }
 


### PR DESCRIPTION
Also documented the correctness of `queue.disable_advancing()` on calls.

Resolves #60 