### PR TITLE
perf: prefer editing npmsgs over creating new ones

### DIFF
--- a/lyra/src/command/require.rs
+++ b/lyra/src/command/require.rs
@@ -104,6 +104,36 @@ impl PlayerInterface {
         self.context.set_pause(state).await?;
         Ok(())
     }
+
+    #[inline]
+    pub async fn cleanup_now_playing_message_and_play(
+        &self,
+        cx: &(impl CacheAware + Sync),
+        index: usize,
+        data_w: &mut PlayerDataWrite<'_>,
+    ) -> LavalinkResult<()> {
+        cleanup_now_playing_message_and_play(&self.context, cx, index, data_w).await
+    }
+
+    pub async fn stop_and_delete_now_playing_message(
+        &self,
+        data_w: &mut PlayerDataWrite<'_>,
+    ) -> LavalinkResult<()> {
+        self.context.stop_now().await?;
+        data_w.delete_now_playing_message().await;
+        Ok(())
+    }
+}
+
+pub async fn cleanup_now_playing_message_and_play(
+    context: &PlayerContext,
+    cx: &(impl CacheAware + Sync),
+    index: usize,
+    data_w: &mut PlayerDataWrite<'_>,
+) -> LavalinkResult<()> {
+    data_w.cleanup_now_playing_message(cx).await;
+    context.play_now(data_w.queue()[index].data()).await?;
+    Ok(())
 }
 
 pub type CachedVoiceStateRef<'a> =

--- a/lyra/src/component/config/now_playing.rs
+++ b/lyra/src/component/config/now_playing.rs
@@ -53,7 +53,7 @@ impl BotSlashCommand for Toggle {
         } else {
             if let Ok(data) = maybe_data {
                 if data.read().await.now_playing_message_id().is_some() {
-                    data.write().await.delete_now_playing_message(&ctx).await;
+                    data.write().await.delete_now_playing_message().await;
                 }
             }
             ("🔕", "Not sending")

--- a/lyra/src/component/connection/leave.rs
+++ b/lyra/src/component/connection/leave.rs
@@ -15,7 +15,7 @@ use crate::{
         model::{BotSlashCommand, CtxKind, GuildCtx},
         require,
     },
-    core::model::{HttpAware, response::initial::message::create::RespondWithMessage},
+    core::model::response::initial::message::create::RespondWithMessage,
     error::{
         CommandResult,
         component::connection::leave::{self, DisconnectCleanupError},
@@ -40,7 +40,7 @@ pub(super) fn disconnect(cx: &(impl SenderAware + GuildIdAware)) -> Result<(), C
 }
 
 pub(super) async fn disconnect_cleanup(
-    cx: &(impl HttpAware + GuildIdAware + LavalinkAware + Sync),
+    cx: &(impl GuildIdAware + LavalinkAware + Sync),
 ) -> Result<(), DisconnectCleanupError> {
     let guild_id = cx.guild_id();
     let lavalink = cx.lavalink();
@@ -51,7 +51,7 @@ pub(super) async fn disconnect_cleanup(
             .data_unwrapped()
             .write()
             .await
-            .delete_now_playing_message(cx)
+            .delete_now_playing_message()
             .await;
     }
     lavalink.drop_connection(guild_id);

--- a/lyra/src/component/controller.rs
+++ b/lyra/src/component/controller.rs
@@ -55,7 +55,7 @@ impl BotSlashCommand for Bump {
             drop(data_r);
 
             let mut data_w = data.write().await;
-            data_w.delete_now_playing_message(&ctx).await;
+            data_w.delete_now_playing_message().await;
             let http = ctx.http_owned();
             data_w
                 .new_now_playing_message_in(http, msg_data, channel_id)

--- a/lyra/src/component/playback/jump/to.rs
+++ b/lyra/src/component/playback/jump/to.rs
@@ -119,18 +119,24 @@ impl BotSlashCommand for To {
         queue.downgrade_repeat_mode();
         if current_track_exist {
             // CORRECTNESS: the current track is present and will be ending via the
-            // `play_now` call later, so this is correct
+            // `cleanup_now_playing_message_and_play` call later, so this is correct
             queue.disable_advancing();
         }
 
         let index = position - 1;
-        let track = queue[index].data();
-        let txt = format!("↔️ Jumped to `{}` (`#{}`).", track.info.title, position);
-        player.context.play_now(track).await?;
-
+        let mapped_index = queue.map_index_expected(index);
+        let track = queue[mapped_index].data();
+        ctx.out(format!(
+            "↔️ Jumped to `{}` (`#{}`).",
+            track.info.title, mapped_index
+        ))
+        .await?;
         *queue.index_mut() = index;
+        player
+            .cleanup_now_playing_message_and_play(&ctx, mapped_index, &mut data_w)
+            .await?;
+
         drop(data_w);
-        ctx.out(txt).await?;
         Ok(())
     }
 }

--- a/lyra/src/component/queue/clear.rs
+++ b/lyra/src/component/queue/clear.rs
@@ -32,16 +32,21 @@ impl BotSlashCommand for Clear {
 
         let positions = (1..=queue.len()).filter_map(NonZeroUsize::new);
         check::all_users_track(queue, positions, in_voice_with_user)?;
+        let current_track_exists = require::current_track(queue).is_ok();
 
-        if require::current_track(queue).is_ok() {
+        if current_track_exists {
             // CORRECTNESS: the current track is present and will be ending via the
-            // `stop_now` call later, so this is correct
+            // `stop_and_cleanup_now_playing_message` call later, so this is correct
             queue.disable_advancing();
 
-            player.context.stop_now().await?;
+            drop(data_r);
+            player
+                .stop_and_delete_now_playing_message(&mut data.write().await)
+                .await?;
+        } else {
+            drop(data_r);
         }
 
-        drop(data_r);
         ctx.get_conn().dispatch(Event::QueueClear).await?;
 
         data.write().await.queue_mut().clear();

--- a/lyra/src/component/queue/play.rs
+++ b/lyra/src/component/queue/play.rs
@@ -427,8 +427,8 @@ async fn handle_load_track_results(
         .await
         .queue_mut()
         .enqueue(total_tracks, ctx.user_id());
-    player.play(first_track.inner()).await?;
     ctx.out_f(format!("{plus} Added {enqueued_text}.")).await?;
+    player.play(first_track.inner()).await?;
     Ok(())
 }
 

--- a/lyra/src/error/lavalink.rs
+++ b/lyra/src/error/lavalink.rs
@@ -14,6 +14,7 @@ pub enum ProcessError {
     DeserialiseBodyFromHttp(#[from] super::core::DeserialiseBodyFromHttpError),
     NewNowPlayingMessage(#[from] NewNowPlayingMessageError),
     NewNowPlayingData(#[from] NewNowPlayingDataError),
+    UpdateNowPlayingMessageError(#[from] UpdateNowPlayingMessageError),
 }
 
 #[derive(Error, Debug)]

--- a/lyra/src/lavalink/model/now_playing/message.rs
+++ b/lyra/src/lavalink/model/now_playing/message.rs
@@ -21,7 +21,11 @@ use twilight_util::builder::embed::{
 };
 
 use crate::{
-    core::{emoji, model::HttpAware, r#static::component::NOW_PLAYING_BUTTON_IDS},
+    core::{
+        emoji,
+        model::{HttpAware, response::EmptyResponseResult},
+        r#static::component::NOW_PLAYING_BUTTON_IDS,
+    },
     error::{
         core::DeserialiseBodyFromHttpError,
         lavalink::{
@@ -204,6 +208,10 @@ impl Message {
         self.data.timestamp = timestamp;
     }
 
+    pub(in super::super) const fn replace_data(&mut self, data: Data) -> Data {
+        std::mem::replace(&mut self.data, data)
+    }
+
     pub async fn apply_update(&self) -> Result<(), UpdateNowPlayingMessageError> {
         self.http
             .update_message(self.channel_id, self.id)
@@ -340,5 +348,10 @@ impl Message {
                 .thumbnail(ImageSource::url(artwork.url())?);
         }
         Ok(embed.build())
+    }
+
+    #[inline]
+    pub(in super::super) async fn delete(self) -> EmptyResponseResult {
+        self.http.delete_message(self.channel_id, self.id).await
     }
 }

--- a/lyra/src/lavalink/track/start.rs
+++ b/lyra/src/lavalink/track/start.rs
@@ -50,11 +50,19 @@ pub(super) async fn impl_start(
     }
 
     let msg_data = NowPlayingData::new(&lavalink_data, guild_id, &data_r, track).await?;
+    let now_playing_message_exists = data_r.now_playing_message_id().is_some();
     drop(data_r);
 
-    data.write()
-        .await
-        .new_now_playing_message(lavalink_data.http_owned(), msg_data)
-        .await?;
+    let mut data_w = data.write().await;
+    if now_playing_message_exists {
+        data_w
+            .update_and_apply_all_now_playing_data(msg_data)
+            .await?;
+    } else {
+        data_w
+            .new_now_playing_message(lavalink_data.http_owned(), msg_data)
+            .await?;
+    }
+    drop(data_w);
     Ok(())
 }

--- a/lyra/src/runner.rs
+++ b/lyra/src/runner.rs
@@ -226,7 +226,7 @@ async fn wait_until_shutdown(
 
     tracing::debug!("deleting all now playing messages...");
     for data in bot.lavalink().iter_player_data() {
-        data.write().await.delete_now_playing_message(bot).await;
+        data.write().await.delete_now_playing_message().await;
     }
 
     tracing::debug!("sending close frames to all shards...");


### PR DESCRIPTION
Prefer editing now-playing messages over creating a new one to save REST API calls (2 > 1) unless it is not at the bottom of the current channel. Also fixed incorrect playback with `/jump *` commands when using a non-standard queue indexer.