### PR TITLE
perf: fix project rebuild even if no files changed

### DIFF
--- a/lyra/build.rs
+++ b/lyra/build.rs
@@ -1,6 +1,6 @@
 pub fn main() {
-    println!("cargo:rerun-if-changed=migrations");
-    println!("cargo:rerun-if-changed=preset");
+    println!("cargo:rerun-if-changed=../migrations");
+    println!("cargo:rerun-if-changed=../preset");
     if let Err(e) = emit() {
         panic!("emit error: {e:?}")
     }


### PR DESCRIPTION
Fix the project being rebuilt even if no files changed. This was introduced by #22, and the mistake was that `migrations/` and `preset/` are directories at the project root, but `build.rs` is in `lyra/` and the cargo emits in it expects the current working directory to be `lyra/` and not project root. As the directory doesn't exist in the specified location, it rebuilds (which is [the documented behaviour](https://doc.rust-lang.org/cargo/faq.html#why-is-cargo-rebuilding-my-code)).