### PR TITLE
fix: rebuild lyra_proc if .env is changed

### DIFF
--- a/lyra/build.rs
+++ b/lyra/build.rs
@@ -1,4 +1,4 @@
-pub fn main() {
+fn main() {
     println!("cargo:rerun-if-changed=../migrations");
     println!("cargo:rerun-if-changed=../preset");
     if let Err(e) = emit() {

--- a/lyra_proc/Cargo.toml
+++ b/lyra_proc/Cargo.toml
@@ -3,6 +3,7 @@ name = "lyra_proc"
 version = "0.9.0"
 rust-version = "1.87"
 edition = "2024"
+build = "build.rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/lyra_proc/build.rs
+++ b/lyra_proc/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("cargo:rerun-if-changed=../.env");
+}


### PR DESCRIPTION
Rebuild `lyra_proc` crate if `.env` is changed, left out of #64. This makes the `/play` sources to be reevaluated every time `.env` changes, instead of incorrectly on every cold build.