### PR TITLE
fix: do not send paused-player notices if paused

### DIFF
--- a/lyra/src/command/require.rs
+++ b/lyra/src/command/require.rs
@@ -88,6 +88,11 @@ impl PlayerInterface {
         Ok(())
     }
 
+    #[inline]
+    pub async fn paused(&self) -> bool {
+        self.data().read().await.paused()
+    }
+
     pub async fn set_pause(&self, state: bool) -> Result<(), SetPauseWithError> {
         let data = self.data();
         let mut data_w = data.write().await;

--- a/lyra/src/component/connection/mod.rs
+++ b/lyra/src/component/connection/mod.rs
@@ -203,12 +203,14 @@ pub async fn handle_voice_state_update(
                 && users_in_voice(ctx, connected_channel_id).is_some_and(|n| n == 0)
             {
                 if let Ok(player) = require::player(ctx) {
-                    player.set_pause(true).await?;
-                    ctx.http()
-                        .create_message(text_channel_id)
-                        .content("⚡▶ Paused `(Bot is not used by anyone)`.")
-                        .flags(MessageFlags::SUPPRESS_NOTIFICATIONS)
-                        .await?;
+                    if !player.paused().await {
+                        player.set_pause(true).await?;
+                        ctx.http()
+                            .create_message(text_channel_id)
+                            .content("⚡▶ Paused `(Bot is not used by anyone)`.")
+                            .flags(MessageFlags::SUPPRESS_NOTIFICATIONS)
+                            .await?;
+                    }
                 }
 
                 traced::tokio_spawn(start_inactivity_timeout(

--- a/lyra/src/component/playback/mod.rs
+++ b/lyra/src/component/playback/mod.rs
@@ -44,6 +44,7 @@ pub async fn handle_voice_state_update(
                     })
             }) && !old_state.suppress()
         })
+        && !player.paused().await
     {
         player.set_pause(true).await?;
         ctx.http()


### PR DESCRIPTION
Fix the paused-player notice messages to be sent even when the player is already paused.