### PR TITLE
fix: stop the last curr track when /skip, /remove*

### DIFF
--- a/lyra/src/component/playback/back.rs
+++ b/lyra/src/component/playback/back.rs
@@ -57,7 +57,7 @@ pub async fn back(
     }
     queue.recede();
 
-    let index = queue.mapped_index().expect("current track exists");
+    let index = queue.current_index().expect("current track exists");
     let message = current_track_title.map_or_else(
         || format!("⏮️ `{}`.", queue[index].data().info.title),
         |title| format!("⏮️ ~~`{title}`~~.",),

--- a/lyra/src/component/playback/skip.rs
+++ b/lyra/src/component/playback/skip.rs
@@ -63,7 +63,7 @@ pub async fn skip(
     queue.disable_advancing();
 
     queue.advance();
-    if let Some(index) = queue.mapped_index() {
+    if let Some(index) = queue.current_index() {
         player
             .cleanup_now_playing_message_and_play(ctx, index, &mut data_w)
             .await?;

--- a/lyra/src/component/queue/mod.rs
+++ b/lyra/src/component/queue/mod.rs
@@ -296,7 +296,7 @@ async fn impl_remove(
         // `stop_and_cleanup_now_playing_message` call later, so this is correct.
         queue.disable_advancing();
 
-        if let Some(index) = queue.mapped_index() {
+        if let Some(index) = queue.current_index() {
             player
                 .cleanup_now_playing_message_and_play(ctx, index, &mut data_w)
                 .await?;

--- a/lyra/src/lavalink/model/queue.rs
+++ b/lyra/src/lavalink/model/queue.rs
@@ -122,7 +122,7 @@ impl Queue {
         &mut self.index
     }
 
-    pub fn map_index(&self, index: usize) -> Option<usize> {
+    fn map_index(&self, index: usize) -> Option<usize> {
         match self.indexer {
             Indexer::Standard => Some(index),
             Indexer::Fair(ref indexer) => indexer.current(index),
@@ -135,17 +135,17 @@ impl Queue {
         self.map_index(index).expect("track at index exists")
     }
 
-    pub fn mapped_index(&self) -> Option<usize> {
-        self.map_index(self.index)
-    }
-
-    pub fn get_mapped(&self, index: usize) -> Option<&Item> {
+    fn get_mapped(&self, index: usize) -> Option<&Item> {
         self.inner.get(self.map_index(index)?)
     }
 
     #[inline]
     pub fn current(&self) -> Option<&Item> {
         self.get_mapped(self.index)
+    }
+
+    pub fn current_index(&self) -> Option<usize> {
+        self.current().map(|_| self.index)
     }
 
     #[inline]

--- a/lyra/src/lavalink/track/end.rs
+++ b/lyra/src/lavalink/track/end.rs
@@ -38,8 +38,7 @@ pub(super) async fn impl_end(
 
         let queue = data_w.queue_mut();
         queue.advance();
-        let index = queue.index();
-        if queue.get_mapped(index).is_some() {
+        if let Some(index) = queue.current_index() {
             cleanup_now_playing_message_and_play(&player, cdata, index, &mut data_w).await?;
         }
         drop(data_w);


### PR DESCRIPTION
Stop the bot's playback of the current track upon `/skip` and `/remove*` commands if the current track is the last track in queue. Prior to this fix, as the queue progresses the playback would get increasingly more desynced with the tracks queue.

Resolves #81