### PR TITLE
fix: bump yt-src to 1.13.3, resolve playback issue

### DIFF
--- a/lavalink/application.yml
+++ b/lavalink/application.yml
@@ -38,8 +38,8 @@ lavalink:
       snapshot: false
     - dependency: "com.github.topi314.lavasearch:lavasearch-plugin:1.0.0"
       snapshot: false
-    - dependency: "dev.lavalink.youtube:youtube-plugin:f2d58254f508633aff49d16876dd9fcf44c34ec6"
-      snapshot: true
+    - dependency: "dev.lavalink.youtube:youtube-plugin:1.13.3"
+      snapshot: false
   server:
     sources:
       youtube: false

--- a/lyra/src/gateway/interaction/mod.rs
+++ b/lyra/src/gateway/interaction/mod.rs
@@ -111,7 +111,8 @@ where
             "💔 **Unable to load track**: \
                     Please ensure the URL is from a supported audio streaming service and \
                     the content is publicly accessible.  \n\
-                    -# **Supported streaming services**: {}.",
+                    -# **Supported streaming services**: {}. \
+                    If you believe this should be loaded, contact the bot developers to report the issue.",
             PlaySource::values().pretty_join_with_and()
         ))
         .await?;


### PR DESCRIPTION
Bump the `youtube-source` Lavalink plugin to `1.13.3`, which should resolve bot's audio playback from YouTube issues. Also added a note to report the issue if the playback is not working again to the bot developers when loading a track fails during `/play`.