### PR TITLE
fix: permission-gate config and tuning commands

### DIFF
--- a/lyra/src/component/config/mod.rs
+++ b/lyra/src/component/config/mod.rs
@@ -4,14 +4,26 @@ pub mod now_playing;
 use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use lyra_proc::BotGuildCommandGroup;
+use twilight_model::guild::Permissions;
 
 use self::{access::Access, now_playing::NowPlaying};
 
 #[derive(CommandModel, CreateCommand, BotGuildCommandGroup)]
-#[command(name = "config", desc = ".", contexts = "guild")]
+#[command(
+    name = "config",
+    desc = ".",
+    contexts = "guild",
+    default_permissions = "Self::default_permissions"
+)]
 pub enum Config {
     #[command(name = "access")]
     Access(Box<Access>),
     #[command(name = "now-playing")]
     NowPlaying(NowPlaying),
+}
+
+impl Config {
+    const fn default_permissions() -> Permissions {
+        Permissions::MANAGE_GUILD
+    }
 }

--- a/lyra/src/component/tuning/equaliser/custom.rs
+++ b/lyra/src/component/tuning/equaliser/custom.rs
@@ -3,7 +3,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 use crate::{
     command::model::GuildSlashCmdCtx,
     component::tuning::{
-        UpdateFilter, check_user_is_dj_and_require_unsuppressed_player, equaliser::SetEqualiser,
+        UpdateFilter, equaliser::SetEqualiser, require_in_voice_unsuppressed_and_player,
     },
     core::model::response::initial::message::create::RespondWithMessage,
 };
@@ -62,7 +62,7 @@ pub struct Custom {
 
 impl crate::command::model::BotGuildSlashCommand for Custom {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> crate::error::CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let equaliser = [
             self.band_1,

--- a/lyra/src/component/tuning/equaliser/mod.rs
+++ b/lyra/src/component/tuning/equaliser/mod.rs
@@ -6,6 +6,9 @@ use lavalink_rs::model::player::{Equalizer, Filters};
 use lyra_ext::num::usize_as_u8;
 use lyra_proc::BotGuildCommandGroup;
 use twilight_interactions::command::{CommandModel, CreateCommand};
+use twilight_model::guild::Permissions;
+
+use crate::command::check::DJ_PERMISSIONS;
 
 const EQUALISER_N: usize = 15;
 
@@ -38,7 +41,12 @@ impl super::ApplyFilter for Option<SetEqualiser> {
 }
 
 #[derive(CommandModel, CreateCommand, BotGuildCommandGroup)]
-#[command(name = "equaliser", desc = ".", contexts = "guild")]
+#[command(
+    name = "equaliser",
+    desc = ".",
+    contexts = "guild",
+    default_permissions = "Self::default_permissions"
+)]
 pub enum Equaliser {
     #[command(name = "preset")]
     Preset(preset::Preset),
@@ -46,4 +54,10 @@ pub enum Equaliser {
     Custom(Box<custom::Custom>),
     #[command(name = "off")]
     Off(off::Off),
+}
+
+impl Equaliser {
+    const fn default_permissions() -> Permissions {
+        DJ_PERMISSIONS
+    }
 }

--- a/lyra/src/component/tuning/equaliser/off.rs
+++ b/lyra/src/component/tuning/equaliser/off.rs
@@ -2,7 +2,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::GuildSlashCmdCtx,
-    component::tuning::{UpdateFilter, check_user_is_dj_and_require_unsuppressed_player},
+    component::tuning::{UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
 };
 
@@ -13,7 +13,7 @@ pub struct Off;
 
 impl crate::command::model::BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> crate::error::CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<super::SetEqualiser>).await?;
         ctx.out("🎛️🔴 Disabled equaliser.").await?;

--- a/lyra/src/component/tuning/equaliser/preset.rs
+++ b/lyra/src/component/tuning/equaliser/preset.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 use crate::{
     command::model::GuildSlashCmdCtx,
     component::tuning::{
-        UpdateFilter, check_user_is_dj_and_require_unsuppressed_player, equaliser::SetEqualiser,
+        UpdateFilter, equaliser::SetEqualiser, require_in_voice_unsuppressed_and_player,
     },
     core::model::response::initial::message::create::RespondWithMessage,
 };
@@ -33,7 +33,7 @@ pub struct Preset {
 
 impl crate::command::model::BotGuildSlashCommand for Preset {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> crate::error::CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let preset_name = self.preset.value();
         let update = Some(SetEqualiser::from(self.preset));

--- a/lyra/src/component/tuning/filter/channel_mix.rs
+++ b/lyra/src/component/tuning/filter/channel_mix.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{UpdateFilter, check_user_is_dj_and_require_unsuppressed_player},
+    component::tuning::{UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -81,7 +81,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetChannelMix::new(
             self.left_to_left,
@@ -112,7 +112,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetChannelMix>).await?;
         ctx.out("⚗️🔴 Disabled channel mix.").await?;

--- a/lyra/src/component/tuning/filter/distortion.rs
+++ b/lyra/src/component/tuning/filter/distortion.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{UpdateFilter, check_user_is_dj_and_require_unsuppressed_player},
+    component::tuning::{UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -82,7 +82,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let distortion = LavalinkDistortion {
             sin_offset: self.sin_offset,
@@ -118,7 +118,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetDistortion>).await?;
         ctx.out("🍭🔴 Disabled distortion.").await?;

--- a/lyra/src/component/tuning/filter/low_pass.rs
+++ b/lyra/src/component/tuning/filter/low_pass.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{UpdateFilter, check_user_is_dj_and_require_unsuppressed_player},
+    component::tuning::{UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -74,7 +74,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetLowPass::new(self.smoothing) else {
             ctx.wrng(format!(
@@ -100,7 +100,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetLowPass>).await?;
         ctx.out("😶‍🌫️🔴 Disabled low pass.").await?;

--- a/lyra/src/component/tuning/filter/mod.rs
+++ b/lyra/src/component/tuning/filter/mod.rs
@@ -12,6 +12,9 @@ use std::marker::PhantomData;
 use lavalink_rs::model::player::{Filters, TremoloVibrato};
 use lyra_proc::BotGuildCommandGroup;
 use twilight_interactions::command::{CommandModel, CreateCommand};
+use twilight_model::guild::Permissions;
+
+use crate::command::check::DJ_PERMISSIONS;
 
 use super::ApplyFilter;
 
@@ -108,7 +111,12 @@ impl ApplyFilter for Option<SetTremoloVibrato<VibratoMarker>> {
 }
 
 #[derive(CommandModel, CreateCommand, BotGuildCommandGroup)]
-#[command(name = "filter", desc = ".", contexts = "guild")]
+#[command(
+    name = "filter",
+    desc = ".",
+    contexts = "guild",
+    default_permissions = "Self::default_permissions"
+)]
 pub enum Filter {
     #[command(name = "tremolo")]
     Tremolo(tremolo::Tremolo),
@@ -126,4 +134,10 @@ pub enum Filter {
     Pitch(pitch::Pitch),
     #[command(name = "all-off")]
     AllOff(all_off::AllOff),
+}
+
+impl Filter {
+    const fn default_permissions() -> Permissions {
+        DJ_PERMISSIONS
+    }
 }

--- a/lyra/src/component/tuning/filter/pitch/down.rs
+++ b/lyra/src/component/tuning/filter/pitch/down.rs
@@ -4,9 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{
-        check_user_is_dj_and_require_unsuppressed_player, filter::pitch::shift_pitch,
-    },
+    component::tuning::{filter::pitch::shift_pitch, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -22,7 +20,7 @@ pub struct Down {
 
 impl BotGuildSlashCommand for Down {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let half_tones = NonZeroI64::new(self.half_tones.unwrap_or(2))
             .expect("half-tones step should be non-zero");

--- a/lyra/src/component/tuning/filter/pitch/set.rs
+++ b/lyra/src/component/tuning/filter/pitch/set.rs
@@ -3,9 +3,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{
-        ApplyFilter, UpdateFilter, check_user_is_dj_and_require_unsuppressed_player,
-    },
+    component::tuning::{ApplyFilter, UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -68,7 +66,7 @@ pub struct Set {
 
 impl BotGuildSlashCommand for Set {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetPitch::new(self.multiplier) else {
             ctx.wrng("Multiplier must not be zero").await?;

--- a/lyra/src/component/tuning/filter/pitch/up.rs
+++ b/lyra/src/component/tuning/filter/pitch/up.rs
@@ -4,9 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{
-        check_user_is_dj_and_require_unsuppressed_player, filter::pitch::shift_pitch,
-    },
+    component::tuning::{filter::pitch::shift_pitch, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -22,7 +20,7 @@ pub struct Up {
 
 impl BotGuildSlashCommand for Up {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let half_tones = NonZeroI64::new(self.half_tones.unwrap_or(2))
             .expect("half-tones step should be non-zero");

--- a/lyra/src/component/tuning/filter/rotation.rs
+++ b/lyra/src/component/tuning/filter/rotation.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::{UpdateFilter, check_user_is_dj_and_require_unsuppressed_player},
+    component::tuning::{UpdateFilter, require_in_voice_unsuppressed_and_player},
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -51,7 +51,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetRotation::new(self.frequency) else {
             ctx.wrng("Frequency must not be zero.").await?;
@@ -75,7 +75,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetRotation>).await?;
         ctx.out("🍳🔴 Disabled rotation.").await?;

--- a/lyra/src/component/tuning/filter/tremolo.rs
+++ b/lyra/src/component/tuning/filter/tremolo.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
     component::tuning::{
-        UpdateFilter, check_user_is_dj_and_require_unsuppressed_player, filter::SetTremolo,
+        UpdateFilter, filter::SetTremolo, require_in_voice_unsuppressed_and_player,
     },
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
@@ -33,7 +33,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetTremolo::new(self.frequency, self.depth) else {
             ctx.wrng("Both frequency and depth must not be zero.")
@@ -56,7 +56,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetTremolo>).await?;
         ctx.out("🎸🔴 Disabled tremolo.").await?;

--- a/lyra/src/component/tuning/filter/vibrato.rs
+++ b/lyra/src/component/tuning/filter/vibrato.rs
@@ -4,7 +4,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
     component::tuning::{
-        UpdateFilter, check_user_is_dj_and_require_unsuppressed_player, filter::SetVibrato,
+        UpdateFilter, filter::SetVibrato, require_in_voice_unsuppressed_and_player,
     },
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
@@ -33,7 +33,7 @@ pub struct On {
 
 impl BotGuildSlashCommand for On {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let Some(update) = SetVibrato::new(self.frequency, self.depth) else {
             ctx.wrng("Both frequency and depth must not be zero.")
@@ -56,7 +56,7 @@ pub struct Off;
 
 impl BotGuildSlashCommand for Off {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         player.update_filter(None::<SetVibrato>).await?;
         ctx.out("🎻🔴 Disabled vibrato.").await?;

--- a/lyra/src/component/tuning/mod.rs
+++ b/lyra/src/component/tuning/mod.rs
@@ -13,42 +13,22 @@ use std::num::NonZeroU16;
 use lavalink_rs::{error::LavalinkResult, model::player::Filters};
 
 use crate::{
-    CommandError, LavalinkAndGuildIdAware, LavalinkAware,
+    LavalinkAndGuildIdAware, LavalinkAware,
     command::{
-        check,
         model::{CtxKind, GuildCtx},
         require::{self, InVoice, PlayerInterface},
     },
     core::model::{BotStateAware, HttpAware},
+    error::component::tuning::RequireInVoiceUnsuppressedAndPlayerError,
     gateway::{GuildIdAware, voice},
     lavalink::{ConnectionHead, DelegateMethods},
 };
 
 #[inline]
-fn check_user_is_dj_and_require_unsuppressed_player(
+fn require_in_voice_unsuppressed_and_player(
     ctx: &GuildCtx<impl CtxKind>,
-) -> Result<(InVoice, PlayerInterface), CommandError> {
-    check::user_is_dj(ctx)?;
+) -> Result<(InVoice, PlayerInterface), RequireInVoiceUnsuppressedAndPlayerError> {
     let in_voice = require::in_voice(ctx)?.and_unsuppressed()?;
-    let player = require::player(ctx)?;
-
-    Ok((in_voice, player))
-}
-
-#[inline]
-fn unmuting_checks(ctx: &GuildCtx<impl CtxKind>) -> Result<InVoice, CommandError> {
-    check::user_is_dj(ctx)?;
-    let in_voice = require::in_voice(ctx)?;
-
-    Ok(in_voice)
-}
-
-#[inline]
-fn check_user_is_dj_and_require_player(
-    ctx: &GuildCtx<impl CtxKind>,
-) -> Result<(InVoice, PlayerInterface), CommandError> {
-    check::user_is_dj(ctx)?;
-    let in_voice = require::in_voice(ctx)?;
     let player = require::player(ctx)?;
 
     Ok((in_voice, player))

--- a/lyra/src/component/tuning/volume/down.rs
+++ b/lyra/src/component/tuning/volume/down.rs
@@ -6,7 +6,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 use crate::{
     LavalinkAndGuildIdAware,
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::check_user_is_dj_and_require_unsuppressed_player,
+    component::tuning::require_in_voice_unsuppressed_and_player,
     core::model::{
         BotStateAware, HttpAware, response::initial::message::create::RespondWithMessage,
     },
@@ -25,7 +25,7 @@ pub struct Down {
 
 impl BotGuildSlashCommand for Down {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let guild_id = ctx.guild_id();
         let data = player.data();

--- a/lyra/src/component/tuning/volume/mod.rs
+++ b/lyra/src/component/tuning/volume/mod.rs
@@ -7,6 +7,7 @@ use std::num::NonZeroU16;
 
 use lyra_proc::BotGuildCommandGroup;
 use twilight_interactions::command::{CommandModel, CreateCommand};
+use twilight_model::guild::Permissions;
 
 pub(super) const fn volume_emoji(percent: Option<NonZeroU16>) -> &'static str {
     let Some(percent) = percent else {
@@ -28,7 +29,12 @@ pub fn clipping_warning(percent: NonZeroU16) -> &'static str {
 }
 
 #[derive(CommandModel, CreateCommand, BotGuildCommandGroup)]
-#[command(name = "volume", desc = ".", contexts = "guild")]
+#[command(
+    name = "volume",
+    desc = ".",
+    contexts = "guild",
+    default_permissions = "Self::default_permissions"
+)]
 pub enum Volume {
     #[command(name = "toggle-mute")]
     ToggleMute(toggle_mute::ToggleMute),
@@ -38,4 +44,10 @@ pub enum Volume {
     Up(up::Up),
     #[command(name = "down")]
     Down(down::Down),
+}
+
+impl Volume {
+    const fn default_permissions() -> Permissions {
+        Permissions::MUTE_MEMBERS
+    }
 }

--- a/lyra/src/component/tuning/volume/set.rs
+++ b/lyra/src/component/tuning/volume/set.rs
@@ -5,7 +5,7 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::check_user_is_dj_and_require_unsuppressed_player,
+    component::tuning::require_in_voice_unsuppressed_and_player,
     core::model::response::initial::message::create::RespondWithMessage,
     error::CommandResult,
 };
@@ -21,7 +21,7 @@ pub struct Set {
 
 impl BotGuildSlashCommand for Set {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let (_, player) = check_user_is_dj_and_require_unsuppressed_player(&ctx)?;
+        let (_, player) = require_in_voice_unsuppressed_and_player(&ctx)?;
 
         let percent =
             NonZeroU16::new(i64_as_u16(self.percent)).expect("percent should be non-zero");

--- a/lyra/src/component/tuning/volume/toggle_mute.rs
+++ b/lyra/src/component/tuning/volume/toggle_mute.rs
@@ -2,8 +2,10 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     LavalinkAndGuildIdAware,
-    command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::unmuting_checks,
+    command::{
+        model::{BotGuildSlashCommand, GuildSlashCmdCtx},
+        require,
+    },
     core::model::{
         BotStateAware, HttpAware, response::initial::message::create::RespondWithMessage,
     },
@@ -18,7 +20,7 @@ pub struct ToggleMute;
 
 impl BotGuildSlashCommand for ToggleMute {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
-        let _ = unmuting_checks(&ctx)?;
+        let _ = require::in_voice(&ctx)?;
 
         let guild_id = ctx.guild_id();
         let mute = ctx.get_conn().toggle_mute().await?;

--- a/lyra/src/component/tuning/volume/up.rs
+++ b/lyra/src/component/tuning/volume/up.rs
@@ -5,8 +5,10 @@ use twilight_interactions::command::{CommandModel, CreateCommand};
 
 use crate::{
     LavalinkAndGuildIdAware,
-    command::model::{BotGuildSlashCommand, GuildSlashCmdCtx},
-    component::tuning::check_user_is_dj_and_require_player,
+    command::{
+        model::{BotGuildSlashCommand, GuildSlashCmdCtx},
+        require,
+    },
     core::model::{
         BotStateAware, HttpAware, response::initial::message::create::RespondWithMessage,
     },
@@ -26,7 +28,8 @@ pub struct Up {
 impl BotGuildSlashCommand for Up {
     async fn run(self, mut ctx: GuildSlashCmdCtx) -> CommandResult {
         const MAX_PERCENT: NonZeroU16 = NonZeroU16::new(1_000).expect("`1_000 is non-zero");
-        let (_, player) = check_user_is_dj_and_require_player(&ctx)?;
+        let _ = require::in_voice(&ctx)?;
+        let player = require::player(&ctx)?;
 
         let guild_id = ctx.guild_id();
         let data = player.data();

--- a/lyra/src/error/command/mod.rs
+++ b/lyra/src/error/command/mod.rs
@@ -35,6 +35,7 @@ pub enum Error {
     UnrecognisedConnection(#[from] super::UnrecognisedConnection),
     NewNowPlayingData(#[from] super::lavalink::NewNowPlayingDataError),
     Lavalink(#[from] lavalink_rs::error::LavalinkError),
+    RequireInVoiceUnsuppressedAndPlayer(#[from] RequireInVoiceUnsuppressedAndPlayerError),
 
     Skip(Box<super::component::playback::skip::SkipError>),
     Back(Box<super::component::playback::back::BackError>),
@@ -123,6 +124,8 @@ pub enum FlattenedError<'a> {
 }
 
 pub use FlattenedError as Fe;
+
+use super::component::tuning::RequireInVoiceUnsuppressedAndPlayerError;
 
 impl<'a> Fe<'a> {
     const fn from_require_unsuppressed_error(error: &'a require::UnsuppressedError) -> Self {
@@ -609,6 +612,18 @@ impl<'a> Fe<'a> {
             }
         }
     }
+
+    const fn from_require_in_voice_unsuppressed_and_player(
+        error: &'a RequireInVoiceUnsuppressedAndPlayerError,
+    ) -> Self {
+        match error {
+            RequireInVoiceUnsuppressedAndPlayerError::NotInVoice(_) => Self::NotInVoice,
+            RequireInVoiceUnsuppressedAndPlayerError::NoPlayer(_) => Self::NoPlayer,
+            RequireInVoiceUnsuppressedAndPlayerError::Unsuppressed(e) => {
+                Self::from_require_unsuppressed_error(e)
+            }
+        }
+    }
 }
 
 impl Error {
@@ -652,6 +667,9 @@ impl Error {
             Self::NewNowPlayingData(e) => Fe::from_new_now_playing_data(e),
             Self::NewNowPlayingMessage(e) => Fe::from_new_now_playing_message(e),
             Self::Respond(e) => Fe::from_respond(e),
+            Self::RequireInVoiceUnsuppressedAndPlayer(e) => {
+                Fe::from_require_in_voice_unsuppressed_and_player(e)
+            }
         }
     }
 }

--- a/lyra/src/error/component/mod.rs
+++ b/lyra/src/error/component/mod.rs
@@ -2,3 +2,4 @@ pub mod connection;
 pub mod misc;
 pub mod playback;
 pub mod queue;
+pub mod tuning;

--- a/lyra/src/error/component/tuning/mod.rs
+++ b/lyra/src/error/component/tuning/mod.rs
@@ -1,0 +1,11 @@
+use thiserror::Error;
+
+use crate::error::{NotInVoice, command::require::UnsuppressedError, lavalink::NoPlayerError};
+
+#[derive(Error, Debug)]
+#[error(transparent)]
+pub enum RequireInVoiceUnsuppressedAndPlayerError {
+    NotInVoice(#[from] NotInVoice),
+    Unsuppressed(#[from] UnsuppressedError),
+    NoPlayer(#[from] NoPlayerError),
+}


### PR DESCRIPTION
Gate `/config *`, `/equaliser *`, `/filter *` and `/volume *` commands behind `MANAGE_GUILD`, DJ permissions (x2) and `MUTE_MEMBERS` permissions accordingly on the command level with permissions v2.

Currently, DJ permissions is `MUTE_MEMBERS` and `MOVE_MEMBERS`.

refs: #26, #27