### PR TITLE
refactor: bump msrv to 1.88, resolve clippy lints

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -209,9 +209,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.18.1"
+version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "793db76d6187cd04dff33004d8e6c9cc4e05cd330500379d2394209271b4aeee"
+checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
 
 [[package]]
 name = "by_address"
@@ -1347,9 +1347,9 @@ checksum = "ce23b50ad8242c51a442f3ff322d56b02f08852c77e4c0b4d3fd684abc89c683"
 
 [[package]]
 name = "indexmap"
-version = "2.9.0"
+version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
+checksum = "fe4cd85333e22411419a0bcae1297d25e58c9443848b11dc6a86fefe8c78a661"
 dependencies = [
  "equivalent",
  "hashbrown 0.15.4",
@@ -1918,9 +1918,9 @@ checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
 
 [[package]]
 name = "owo-colors"
-version = "4.2.1"
+version = "4.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26995317201fa17f3656c36716aed4a7c81743a9634ac4c99c0eeda495db0cec"
+checksum = "48dd4f4a2c8405440fd0462561f0e5806bd0f77e86f51c761481bdd4018b545e"
 
 [[package]]
 name = "palette"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM lukemathwalker/cargo-chef:latest-rust-1.87-bookworm AS chef
+FROM lukemathwalker/cargo-chef:latest-rust-1.88-bookworm AS chef
 WORKDIR /app
 
 # The generated recipe.json should only change if the dependencies changed

--- a/flake.lock
+++ b/flake.lock
@@ -43,11 +43,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750615580,
-        "narHash": "sha256-8ucRXBCG5vA1nHCH1agRDBZaiuPKuqb/RsPxQEsHeVk=",
+        "lastModified": 1751035284,
+        "narHash": "sha256-yumBn+RU3dyums7laPhD8dbE0oqCLoz/5a0pCcR5lrs=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "e5dfaa34eed24f1ec79e99624666b15f51c4be97",
+        "rev": "472fe807b405619ee7b30e3d6a6dcc7a6c77a36a",
         "type": "github"
       },
       "original": {
@@ -64,11 +64,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1750660809,
-        "narHash": "sha256-+1f42Xww2Q/dUSH4ZPatLaBrN2393srw4dy8RK3BjGA=",
+        "lastModified": 1751006353,
+        "narHash": "sha256-icKFXb83uv2ezRCfuq5G8QSwCuaoLywLljSL+UGmPPI=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "f2eb76a4605b0f055e2a9eac47fe1797f19d21c1",
+        "rev": "b37f026b49ecb295a448c96bcbb0c174c14fc91b",
         "type": "github"
       },
       "original": {
@@ -181,11 +181,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1750117611,
-        "narHash": "sha256-LTwASICtyN3AjzlF9l2ZNAIVZqclio3yRcwwZy3QSJA=",
+        "lastModified": 1750955511,
+        "narHash": "sha256-IDB/oh/P63ZTdhgSkey2LZHzeNhCdoKk+4j7AaPe1SE=",
         "owner": "cachix",
         "repo": "nix",
-        "rev": "9e4fc95c388e2223d47da865503dee20d179776a",
+        "rev": "afa41b08df4f67b8d77a8034b037ac28c71c77df",
         "type": "github"
       },
       "original": {
@@ -238,11 +238,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1750566911,
-        "narHash": "sha256-RckP9H/P3zGobUBCjESmP9GWIqrgGsUw6nQjyo38+5c=",
+        "lastModified": 1750871759,
+        "narHash": "sha256-hMNZXMtlhfjQdu1F4Fa/UFiMoXdZag4cider2R9a648=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "0100bc737358e56f5dc2fc7d3c15b8a69cefb56b",
+        "rev": "317542c1e4a3ec3467d21d1c25f6a43b80d83e7d",
         "type": "github"
       },
       "original": {

--- a/lyra/Cargo.toml
+++ b/lyra/Cargo.toml
@@ -5,7 +5,7 @@ description = "A featureful, self-hostable Discord music bot."
 version = "0.9.2"
 edition = "2024"
 # When bumping, bump in other Cargo.toml files, Dockerfile too
-rust-version = "1.87"
+rust-version = "1.88"
 license = "GPL-3.0"
 repository = "https://github.com/lyra-music/lyra"
 authors = ["fdnt7"]

--- a/lyra/src/component/config/now_playing.rs
+++ b/lyra/src/component/config/now_playing.rs
@@ -39,24 +39,24 @@ impl BotGuildSlashCommand for Toggle {
 
         let maybe_data = require::player(&ctx).map(|p| p.data());
         let (emoji, action) = if new_now_playing {
-            if let Ok(data) = maybe_data {
-                let data_r = data.read().await;
-                if let Ok(track) = require::current_track(data_r.queue()) {
-                    let (c_data, gid) = (ctx.lavalink().data(), ctx.guild_id().into());
-                    let np_data = NowPlayingData::new(&c_data, gid, &data_r, track.track).await?;
-                    drop(data_r);
-                    data.write()
-                        .await
-                        .new_now_playing_message_in(ctx.http_owned(), np_data, ctx.channel_id())
-                        .await?;
-                }
+            if let Ok(data) = maybe_data
+                && let data_r = data.read().await
+                && let Ok(track) = require::current_track(data_r.queue())
+            {
+                let (c_data, gid) = (ctx.lavalink().data(), ctx.guild_id().into());
+                let np_data = NowPlayingData::new(&c_data, gid, &data_r, track.track).await?;
+                drop(data_r);
+                data.write()
+                    .await
+                    .new_now_playing_message_in(ctx.http_owned(), np_data, ctx.channel_id())
+                    .await?;
             }
             ("🔔", "Sending")
         } else {
-            if let Ok(data) = maybe_data {
-                if data.read().await.now_playing_message_id().is_some() {
-                    data.write().await.delete_now_playing_message().await;
-                }
+            if let Ok(data) = maybe_data
+                && data.read().await.now_playing_message_id().is_some()
+            {
+                data.write().await.delete_now_playing_message().await;
             }
             ("🔕", "Not sending")
         };

--- a/lyra/src/component/tuning/volume/mod.rs
+++ b/lyra/src/component/tuning/volume/mod.rs
@@ -23,9 +23,11 @@ pub(super) const fn volume_emoji(percent: Option<NonZeroU16>) -> &'static str {
 }
 
 pub fn clipping_warning(percent: NonZeroU16) -> &'static str {
-    (percent.get() > 100)
-        .then_some(" (**`Audio quality may be reduced`**)")
-        .unwrap_or_default()
+    if percent.get() > 100 {
+        " (**`Audio quality may be reduced`**)"
+    } else {
+        Default::default()
+    }
 }
 
 #[derive(CommandModel, CreateCommand, BotGuildCommandGroup)]

--- a/lyra/src/component/tuning/volume/up.rs
+++ b/lyra/src/component/tuning/volume/up.rs
@@ -65,9 +65,11 @@ impl BotGuildSlashCommand for Up {
         let emoji = super::volume_emoji(Some(new_percent));
         let warning = super::clipping_warning(new_percent);
 
-        let maxed_note = (new_percent == MAX_PERCENT)
-            .then_some(" (`Max`)")
-            .unwrap_or_default();
+        let maxed_note = if new_percent == MAX_PERCENT {
+            " (`Max`)"
+        } else {
+            Default::default()
+        };
 
         player.context.set_volume(new_percent.get()).await?;
         data.write().await.set_volume(new_percent);

--- a/lyra/src/lavalink/model/now_playing/message.rs
+++ b/lyra/src/lavalink/model/now_playing/message.rs
@@ -132,17 +132,17 @@ impl std::fmt::Display for Description<'_> {
         DurationLeft::from(data).fmt(f)?;
         f.write_str(" / ")?;
         data.duration.pretty_display().fmt(f)?;
-        if let Some(p) = data.preview() {
-            if p.is_preview || p.url().is_some() {
-                f.write_str("\n-# ")?;
-                if p.is_preview {
-                    f.write_str("This track is a preview. ")?;
-                }
-                if let Some(url) = p.url() {
-                    f.write_str("Listen to the preview of this track [here](")?;
-                    f.write_str(url)?;
-                    f.write_str("). ")?;
-                }
+        if let Some(p) = data.preview()
+            && (p.is_preview || p.url().is_some())
+        {
+            f.write_str("\n-# ")?;
+            if p.is_preview {
+                f.write_str("This track is a preview. ")?;
+            }
+            if let Some(url) = p.url() {
+                f.write_str("Listen to the preview of this track [here](")?;
+                f.write_str(url)?;
+                f.write_str("). ")?;
             }
         }
         Ok(())

--- a/lyra_ext/Cargo.toml
+++ b/lyra_ext/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lyra_ext"
 version = "0.9.2"
-rust-version = "1.87"
+rust-version = "1.88"
 edition = "2024"
 
 [lints.rust]

--- a/lyra_proc/Cargo.toml
+++ b/lyra_proc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lyra_proc"
 version = "0.9.2"
-rust-version = "1.87"
+rust-version = "1.88"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/lyra_proc/src/command.rs
+++ b/lyra_proc/src/command.rs
@@ -90,7 +90,7 @@ pub fn impl_bot_command_group(input: &DeriveInput, guild: bool) -> TokenStream {
         _ => panic!("this can only be derived from an enum"),
     };
 
-    let guild_str = guild.then_some(GUILD_STR).unwrap_or_default();
+    let guild_str = if guild { GUILD_STR } else { Default::default() };
     let bot_slash_command_path = syn::parse_str::<Path>(&format!(
         "crate::command::model::Bot{guild_str}SlashCommand"
     ))
@@ -147,7 +147,7 @@ pub fn impl_bot_autocomplete_group(input: &DeriveInput, guild: bool) -> TokenStr
         _ => panic!("this can only be derived from an enum"),
     };
 
-    let guild_str = guild.then_some(GUILD_STR).unwrap_or_default();
+    let guild_str = if guild { GUILD_STR } else { Default::default() };
     let bot_autocomplete_path = syn::parse_str::<Path>(&format!(
         "crate::command::model::Bot{guild_str}Autocomplete"
     ))


### PR DESCRIPTION
Bump the MSRV to 1.88, resolve clippy 1.88 lint and utilise let chains wherever possible.