### PR TITLE
chore(devenv): use secretspec over own dotenv impl

### DIFF
--- a/devenv.nix
+++ b/devenv.nix
@@ -5,7 +5,7 @@
   inputs,
   ...
 }: let
-  configEnv = config.env;
+  configEnv = config.secretspec.secrets;
   lavalinkDir = "./lavalink"; # use `config.git.root` on devenv 1.10
   lavalinkJar = "Lavalink.jar";
 in {
@@ -203,5 +203,5 @@ in {
 
   # See full reference at https://devenv.sh/reference/options/
 
-  dotenv.enable = true;
+  dotenv.disableHint = true; # already managed by secretspec
 }

--- a/devenv.yaml
+++ b/devenv.yaml
@@ -6,3 +6,7 @@ inputs:
     inputs:
       nixpkgs:
         follows: nixpkgs
+secretspec:
+  enable: true
+  provider: dotenv 
+  profile: default

--- a/secretspec.toml
+++ b/secretspec.toml
@@ -1,0 +1,38 @@
+[project]
+name = "lyra"
+revision = "1.0"
+# Extend configurations from subdirectories
+# extends = [ "subdir1", "subdir2" ]
+
+[profiles.default]
+PLUGINS_LAVASRC_SPOTIFY_CLIENT_SECRET = { description = "PLUGINS_LAVASRC_SPOTIFY_CLIENT_SECRET secret", required = true }
+POSTGRES_HOST = { description = "POSTGRES_HOST secret", required = true }
+PLUGINS_YOUTUBE_OAUTH_ENABLED = { description = "PLUGINS_YOUTUBE_OAUTH_ENABLED secret", required = true }
+DOCKER_LAVALINK_PLUGINS_PATH = { description = "DOCKER_LAVALINK_PLUGINS_PATH secret", required = true }
+LAVALINK_SERVER_PASSWORD = { description = "LAVALINK_SERVER_PASSWORD secret", required = true }
+BOT_TOKEN = { description = "BOT_TOKEN secret", required = true }
+SERVER_PORT = { description = "SERVER_PORT secret", required = true }
+DATABASE_URL = { description = "DATABASE_URL secret", required = true }
+PLUGINS_LAVASRC_SPOTIFY_CLIENT_ID = { description = "PLUGINS_LAVASRC_SPOTIFY_CLIENT_ID secret", required = true }
+POSTGRES_USER = { description = "POSTGRES_USER secret", required = true }
+POSTGRES_DB = { description = "POSTGRES_DB secret", required = true }
+LOGGING_LEVEL_ROOT = { description = "LOGGING_LEVEL_ROOT secret", required = true }
+PLUGINS_LAVASRC_DEEZER_ARL = { description = "PLUGINS_LAVASRC_DEEZER_ARL secret", required = true }
+DOCKER_BUILD_TYPE = { description = "DOCKER_BUILD_TYPE secret", required = true }
+DOCKER_POSTGRES_PATH = { description = "DOCKER_POSTGRES_PATH secret", required = true }
+POSTGRES_PORT = { description = "POSTGRES_PORT secret", required = true }
+PLUGINS_LAVASRC_SOURCES_DEEZER = { description = "PLUGINS_LAVASRC_SOURCES_DEEZER secret", required = true }
+POSTGRES_PASSWORD = { description = "POSTGRES_PASSWORD secret", required = true }
+SERVER_ADDRESS = { description = "SERVER_ADDRESS secret", required = true }
+PLUGINS_LAVASRC_DEEZER_MASTER_DECRYPTION_KEY = { description = "PLUGINS_LAVASRC_DEEZER_MASTER_DECRYPTION_KEY secret", required = true }
+LOGGING_LEVEL_LAVALINK = { description = "LOGGING_LEVEL_LAVALINK secret", required = true }
+PLUGINS_LAVASRC_SOURCES_SPOTIFY = { description = "PLUGINS_LAVASRC_SOURCES_SPOTIFY secret", required = true }
+# DATABASE_URL = { description = "Database connection string", required = true }
+
+[profiles.development]
+# Development profile inherits all secrets from default profile
+# Only define secrets here that need different values or settings than default
+# DATABASE_URL = { default = "sqlite:///dev.db" }
+#
+# New secrets
+# REDIS_URL = { description = "Redis connection URL for caching", required = false, default = "redis://localhost:6379" }


### PR DESCRIPTION
Use `secretspec` for `.env` file management instead of `devenv`'s own implementation in the `dotenv` option as it doesn't support substituted variable expansions.

ref: https://github.com/cachix/devenv/issues/2176